### PR TITLE
Support multiple queries as a source of the sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ end
 
 ## roadmap
 Currently this service is very much a proof of concept, the following improvements should be made:
- - support multiple queries as a source of the sitemap
  - regenerate the sitemap after a certain time
  - support batching for queries so long running queries can be optimized in batches
  - use auth-sudo for queries

--- a/app.js
+++ b/app.js
@@ -24,7 +24,8 @@ function returnSitemap(res) {
 async function ensureSitemapExists() {
   if (!fs.existsSync(sitemapPath)) {
     // if file doesn't exist
-    var urls = await querySitemapResources();
+    var urls = await querySitemapResources([], '/config/', '.rq');
+
     if (urls.length) {
       const baseUrl = new URL(urls[0]).origin;
       urls.unshift(baseUrl);
@@ -33,11 +34,22 @@ async function ensureSitemapExists() {
   }
 }
 
-async function querySitemapResources() {
-  const queryString = fs.readFileSync('/config/query.rq').toString('utf-8');
-
-  const result = await query(queryString);
-  return result.results.bindings.map((row) => row['url'].value);
+async function querySitemapResources(urls, folderPath, fileExtension) {
+  const files = fs.readdirSync(folderPath);
+  for (var i = 0; i < files.length; i++) {
+    const filename = folderPath + files[i];
+    const stat = fs.statSync(filename);
+    if (stat.isDirectory()) {
+      // Recursive call
+      const folder = filename + '/';
+      urls = urls.concat(await querySitemapResources(urls, folder, fileExtension));
+    } else if (filename.indexOf(fileExtension) >= 0) {
+      const queryString = fs.readFileSync(filename).toString('utf-8');
+      const result = await query(queryString);
+      urls = result.results.bindings.map((row) => row['url'].value);
+    };
+  };
+  return urls;
 }
 
 async function buildSitemap(urls) {

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { app, query } from 'mu';
 import xmlbuilder from 'xmlbuilder';
+import path from 'path';
 
 const sitemapPath = 'sitemap.xml';
 
@@ -37,12 +38,11 @@ async function ensureSitemapExists() {
 async function querySitemapResources(urls, folderPath, fileExtension) {
   const files = fs.readdirSync(folderPath);
   for (var i = 0; i < files.length; i++) {
-    const filename = folderPath + files[i];
+    const filename = path.join(folderPath, files[i]);
     const stat = fs.statSync(filename);
     if (stat.isDirectory()) {
       // Recursive call
-      const folder = filename + '/';
-      urls = urls.concat(await querySitemapResources(urls, folder, fileExtension));
+      urls = urls.concat(await querySitemapResources(urls, filename, fileExtension));
     } else if (filename.indexOf(fileExtension) >= 0) {
       const queryString = fs.readFileSync(filename).toString('utf-8');
       const result = await query(queryString);


### PR DESCRIPTION
This PR refers to the following roadmap point : 

> - support multiple queries as a source of the sitemap

With this change we can now have several configuration files, we can also sort them into folders if we want to keep it organized.
The code will look recursively into the folders and files contained in the `config/` folder, execute the queries and concatenate the URLs returned.

Feedback is welcome ! :)